### PR TITLE
Fix for make -j

### DIFF
--- a/libNoRSX/Makefile
+++ b/libNoRSX/Makefile
@@ -69,7 +69,7 @@ ppu:
 	@$(MAKE) PLATFORM=ppu lib -C ppu -f $(CURDIR)/Makefile
 
 #---------------------------------------------------------------------------------
-install:
+install: ppu
 #---------------------------------------------------------------------------------
 	@[ -d $(PORTLIBS)/lib ] || mkdir -p $(PORTLIBS)/lib
 	@cp -frv $(CURDIR)/lib/ppu/*.a $(PORTLIBS)/lib


### PR DESCRIPTION
Build fails if make is called with `make -j` or `MAKEFLAGS` are set to `-j`, like in my case when I started the ps3toolchain build.

Errors like
`cp: cannot stat '/home/daren/code/ps3toolchain/build/ps3libraries/build/NoRSX/libNoRSX/lib/ppu/*.a': No such file or directory`
happen.

PR fixes this by adding the `ppu` job dependency to the `install` job.